### PR TITLE
Feature/routes/protected

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,23 +12,27 @@ import PostDetail from "./routes/community/PostDetail";
 import PostList from "./routes/community/PostList";
 import Profile from "./routes/accounts/Profile";
 import ChatBot from "./routes/ChatBot";
+import ProtectedRouter from "./routes/ProtectedRouter";
 
 function App() {
   return (
     <div className="container mx-auto">
       <Navbar />
       <Routes>
-        <Route path="" element={<Home />} />
-        <Route path="signup/" element={<Signup />} />
-        <Route path="signin/" element={<Signin />} />
-        <Route path="mypage/" element={<Mypage />} />
-        <Route path=":nickname/" element={<Profile />} />
-        <Route path="password/" element={<Changepassword />} />
-        <Route path="community/" element={<PostList />} />
-        <Route path="community/new/" element={<CreatePost />} />
-        <Route path="community/:postID/" element={<PostDetail />} />
-        <Route path="community/:postID/edit/" element={<EditPost />} />
-        <Route path="chatbot/" element={<ChatBot />} />
+        <Route path="/" element={<Home />} />                                    {/* 메인페이지 */}
+        <Route path="signup/" element={<Signup />} />                            {/* 회원가입 페이지 */}
+        <Route path="signin/" element={<Signin />} />                            {/* 로그인 페이지 */} 
+        {/* 로그인 후 접근 가능한 페이지 */}
+        <Route element={<ProtectedRouter />}>
+          <Route path="community/new/" element={<CreatePost />} />               {/* 게시글 작성 페이지 */}
+          <Route path="community/:postID/edit/" element={<EditPost />} />        {/* 게시글 수정 페이지 */}
+          <Route path="mypage/" element={<Mypage />} />                          {/* 마이페이지(프로필 수정) */}
+          <Route path="password/" element={<Changepassword />} />                {/* 비밀번호 변경 페이지 */}
+          <Route path="chatbot/" element={<ChatBot />} />                        {/* 챗봇 페이지 */}
+          <Route path=":nickname/" element={<Profile />} />                      {/* 프로필 페이지 */}
+        </Route>
+        <Route path="community/" element={<PostList />} />                       {/* 게시글 목록 페이지 */}
+        <Route path="community/:postID/" element={<PostDetail />} />             {/* 게시글 상세 페이지 */}
       </Routes>
     </div>
   );

--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -5,6 +5,7 @@ import { commentAPI, privateCommunityAPI } from "../api/communityApi";
 import { Link, useParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { authUser } from "../recoil/authAtom";
+import ProtectedButton from "./ProtectedButton";
 
 function Comment({ comment: initialComment, onDeleteSuccess }) {
   const baseURL = import.meta.env.VITE_BASE_URL;
@@ -191,16 +192,22 @@ function Comment({ comment: initialComment, onDeleteSuccess }) {
 
         {makeReply ? (
           <div className="py-5 m-1">
-            <form id="reply-form" className="flex pl-10" onSubmit={onMakeReply}>
-              <input
-                id="reply-input"
-                className="border-2 border-gray-300 rounded-md w-full pl-3"
-                placeholder="comment"
-              />
-              <div className="px-1">
-                <Button buttonName="submit" />
-              </div>
-            </form>
+            <ProtectedButton to={`/community/${postID}/`}>
+              <form
+                id="reply-form"
+                className="flex pl-10"
+                onSubmit={onMakeReply}
+              >
+                <input
+                  id="reply-input"
+                  className="border-2 border-gray-300 rounded-md w-full pl-3"
+                  placeholder="comment"
+                />
+                <div className="px-1">
+                  <Button buttonName="submit" />
+                </div>
+              </form>
+            </ProtectedButton>
             {comment.reply_comments.length === 0 ? (
               <div className="flex flex-col w-full pl-10 p-3 text-gray-400">
                 첫 번째 답글을 작성해보세요!

--- a/src/components/ProtectedButton.jsx
+++ b/src/components/ProtectedButton.jsx
@@ -1,0 +1,26 @@
+import { useRecoilValue } from "recoil";
+import { isAuthenticated } from "../recoil/authAtom";
+import { useNavigate } from "react-router-dom";
+
+function ProtectedButton({ to, children }) {
+  const isAuth = useRecoilValue(isAuthenticated);
+  const navigate = useNavigate();
+
+  const onclick = () => {
+    if (isAuth) {
+      navigate(to); // 로그인 되어 있으면 정상 이동
+    } else {
+      const confirm = window.confirm(
+        "로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?"
+      );
+      if (confirm) {
+        // 로그인 페이지로 이동, 원래 가려고 했던 페이지 저장
+        navigate("/signin", { state: { redirectedFrom: { pathname: to } } });
+      }
+    }
+  };
+
+  return <div onClick={onclick}>{children}</div>;
+}
+
+export default ProtectedButton;

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -1,5 +1,5 @@
 import Button from "../components/Button";
-import { Link } from "react-router-dom";
+import ProtectedButton from "../components/ProtectedButton";
 
 function Home() {
   return (
@@ -9,9 +9,9 @@ function Home() {
           <strong className="text-black text-6xl m-3 mt-5 pt-10 ">맛P.T</strong>
           <p className="text-gray-500 text-2xl m-2">subtitle</p>
           <div className="m-2">
-            <Link to="/chatbot">
+            <ProtectedButton to="/chatbot">
               <Button buttonName="start" />
-            </Link>
+            </ProtectedButton>
           </div>
         </div>
       </div>

--- a/src/routes/ProtectedRouter.jsx
+++ b/src/routes/ProtectedRouter.jsx
@@ -1,0 +1,16 @@
+import { Outlet, Navigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { isAuthenticated } from "../recoil/authAtom";
+
+const ProtectedRouter = () => {
+  const isAuth = useRecoilValue(isAuthenticated); // 로그인 여부 확인
+
+  // 로그인 안되어있으면 로그인 페이지로 리다이렉트
+  if (!isAuth) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRouter;

--- a/src/routes/ProtectedRouter.jsx
+++ b/src/routes/ProtectedRouter.jsx
@@ -1,13 +1,20 @@
-import { Outlet, Navigate } from "react-router-dom";
+import { Outlet, Navigate, useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { isAuthenticated } from "../recoil/authAtom";
 
 const ProtectedRouter = () => {
   const isAuth = useRecoilValue(isAuthenticated); // 로그인 여부 확인
+  const currentLocation = useLocation();
 
   // 로그인 안되어있으면 로그인 페이지로 리다이렉트
   if (!isAuth) {
-    return <Navigate to="/signin" replace />;
+    return (
+      <Navigate
+        to="/signin"
+        replace
+        state={{ redirectedFrom: currentLocation }}
+      />
+    );
   }
 
   return <Outlet />;

--- a/src/routes/accounts/Signin.jsx
+++ b/src/routes/accounts/Signin.jsx
@@ -1,6 +1,6 @@
 import Button from "../../components/Button";
 import Input from "../../components/Input";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { publicAccountAPI } from "../../api/accountApi";
 import { useSetRecoilState } from "recoil";
 import { isAuthenticated, authUser } from "../../recoil/authAtom";
@@ -9,6 +9,8 @@ function Signin() {
   const navigate = useNavigate();
   const setIsAuth = useSetRecoilState(isAuthenticated);
   const setAuthUser = useSetRecoilState(authUser);
+  const location = useLocation();
+  const redirectedFrom = location?.state?.redirectedFrom?.pathname || "/";
 
   const onSubmit = (event) => {
     event.preventDefault();
@@ -29,7 +31,7 @@ function Signin() {
           nickname: response.data.nickname,
           profileImg: response.data.profile_img,
         });
-        navigate("/");
+        navigate(redirectedFrom);
       })
       .catch((error) => {
         console.log(error);

--- a/src/routes/community/PostDetail.jsx
+++ b/src/routes/community/PostDetail.jsx
@@ -9,6 +9,7 @@ import {
 import { useRecoilValue } from "recoil";
 import { authUser } from "../../recoil/authAtom";
 import defaultProfile from "/image.png";
+import ProtectedButton from "../../components/ProtectedButton";
 
 function PostDetail() {
   const baseURL = import.meta.env.VITE_BASE_URL;
@@ -151,16 +152,22 @@ function PostDetail() {
           {/* 댓글 */}
           <div className="border-t-2 border-gray-300 min-w-[200px]">
             <div className="py-5 m-1">
-              <form id="comment-form" className="flex" onSubmit={submitComment}>
-                <input
-                  id="comment-input"
-                  className="border-2 border-gray-300 rounded-md w-full pl-3"
-                  placeholder="comment"
-                />
-                <div className="px-1">
-                  <Button buttonName="submit" />
-                </div>
-              </form>
+              <ProtectedButton to={`/community/${postID}/`}>
+                <form
+                  id="comment-form"
+                  className="flex"
+                  onSubmit={submitComment}
+                >
+                  <input
+                    id="comment-input"
+                    className="border-2 border-gray-300 rounded-md w-full pl-3"
+                    placeholder="comment"
+                  />
+                  <div className="px-1">
+                    <Button buttonName="submit" />
+                  </div>
+                </form>
+              </ProtectedButton>
             </div>
             {comments.map((comment) => (
               <Comment

--- a/src/routes/community/PostList.jsx
+++ b/src/routes/community/PostList.jsx
@@ -4,6 +4,7 @@ import Button from "../../components/Button";
 import defaultImage from "/no-image.png";
 import { publicCommunityAPI } from "../../api/communityApi";
 import PageNation from "../../components/PageNation";
+import ProtectedButton from "../../components/ProtectedButton";
 
 function PostList() {
   // 쿼리스트링
@@ -111,15 +112,15 @@ function PostList() {
       )}
       {/* 고정된 게시글 작성 버튼 */}
       <div className="fixed bottom-10 right-40 shadow-lg">
-        <Link to="/community/new">
+        <ProtectedButton to="/community/new">
           <Button
             buttonName="✏️ 게시글 작성"
-            textColor="black"  
+            textColor="black"
             bgColor="white"
             borderColor="gray"
             textSize="md"
           />
-        </Link>
+        </ProtectedButton>
       </div>
     </div>
   );


### PR DESCRIPTION
비로그인 사용자의 회원 전용 페이지 접근을 막았습니다.
회원 전용 페이지 : 챗봇, 게시글 작성, 게시글 수정, 프로필 페이지, 프로필 수정 페이지(마이페이지), 패스워드 변경 페이지

1. url
- 비로그인 사용자가 url로 회원 전용 페이지 입장시 로그인 페이지로 이동하도록 추가하였습니다.
- 로그인 후 기존에 이용하려했던 회원 전용 페이지로 이동됩니다.

2. 버튼
- 비로그인 사용자가 버튼 클릭으로 회원 전용 페이지 입장시 확인창이 뜹니다
- 확인창에서 로그인 페이지로 이동 여부를 확인합니다
- 로그인페이지로 이동 후 이동이 완료되면 이동하려고 한 회원 전용 페이지로 이동됩니다
- 비로그인 상태에서 댓글작성, 대댓글 작성 시도 할 때 input 박스를 누르면 confirm창이 활성화됩니다.

